### PR TITLE
Add missing symlinks

### DIFF
--- a/vendor/assets/stylesheets/_elements.scss
+++ b/vendor/assets/stylesheets/_elements.scss
@@ -1,0 +1,1 @@
+../../../govuk_elements/packages/govuk-elements-sass/public/sass/_elements.scss

--- a/vendor/assets/stylesheets/_frontend-toolkit.scss
+++ b/vendor/assets/stylesheets/_frontend-toolkit.scss
@@ -1,0 +1,1 @@
+../../../govuk_elements/packages/govuk-elements-sass/public/sass/_frontend-toolkit.scss


### PR DESCRIPTION
These files should have been symlinked when
alphagov/govuk_elements_rails#35 was merged but they were missed.

Also related to alphagov/govuk_elements_rails#33